### PR TITLE
Fix invalid call to `kv.Cursor.Current` after a nil `Seek` in `ChunkLocator`

### DIFF
--- a/cmd/rpcdaemon/commands/otterscan_types.go
+++ b/cmd/rpcdaemon/commands/otterscan_types.go
@@ -42,7 +42,10 @@ const MaxBlockNum = ^uint64(0)
 func newCallChunkLocator(cursor kv.Cursor, addr common.Address, navigateForward bool) ChunkLocator {
 	return func(minBlock uint64) (ChunkProvider, bool, error) {
 		searchKey := callIndexKey(addr, minBlock)
-		_, _, err := cursor.Seek(searchKey)
+		k, _, err := cursor.Seek(searchKey)
+		if k == nil {
+			return nil, false, nil
+		}
 		if err != nil {
 			return nil, false, err
 		}


### PR DESCRIPTION
Using Otterscan in a local testnet, I stumbled upon a rare error when calling `ots_searchTransactionsBefore` for a genesis-allocated address (which sent a few transactions, but never was the recipient of any.)

The issue was that `newCallChunkLocator` was calling `Seek` on the 'to' index cursor, received a `nil` (as the address was never a recipient) and then proceeded to call `Current` in `newCallChunkProvider` which returned the error:

```
mdbx_cursor_get: no data available
```

This small change fixed it for me.